### PR TITLE
feature/dra 49 create category crud flow (#11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,10 @@ COPY --from=build /drakenfruit-portaal/public /drakenfruit-portaal/public
 COPY --from=deps /drakenfruit-portaal/public/tinymce /drakenfruit-portaal/public/tinymce
 ADD . .
 
+RUN --mount=type=secret,id=PROD_DATABASE_URL \
+  DATABASE_URL=$(cat /run/secrets/PROD_DATABASE_URL)
+
+RUN npx prisma generate
+RUN npx prisma migrate deploy
+
 CMD ["npm", "start"]

--- a/app/components/ArticleMutationForm.tsx
+++ b/app/components/ArticleMutationForm.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFetcher } from '@remix-run/react';
 import slugify from '@sindresorhus/slugify';
-import { type SerializedArticle as Article } from '~/models/articles.server';
-import { type ArticleValidationErrors } from '~/types/Article';
+import {
+  type ArticleFormValues,
+  type ArticleValidationErrors,
+} from '~/types/Article';
 import TextInput from '~/components/TextInput';
 import Editor from '~/components/Editor';
 import Label from '~/components/Label';
@@ -24,15 +26,6 @@ import { type User } from '~/models/user.server';
 import { type APIResponse } from '~/types/Responses';
 import Message from '~/components/Message';
 import { type ArticleErrors } from '~/types/Validations';
-
-export type ArticleFormValues = Omit<
-  Article,
-  'id' | 'published' | 'createdAt' | 'updatedAt'
-> & {
-  id?: string;
-  categories: string[];
-  published?: boolean;
-};
 
 type Props = {
   mode: 'create' | 'update';

--- a/app/components/CategoryMutationForm.stories.tsx
+++ b/app/components/CategoryMutationForm.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CategoryMutationForm from './CategoryMutationForm';
+
+export default {
+  title: 'Forms/Category',
+  component: CategoryMutationForm,
+  decorators: [
+    (Story) => (
+      <div className="w-[75vw]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof CategoryMutationForm>;
+
+type Story = StoryObj<typeof CategoryMutationForm>;
+
+export const Default: Story = {
+  args: {
+    mode: 'create',
+    backLink: '',
+    backLinkLabel: 'Back to categories',
+  },
+};

--- a/app/components/CategoryMutationForm.tsx
+++ b/app/components/CategoryMutationForm.tsx
@@ -1,0 +1,254 @@
+import {
+  type CategoryFormValues,
+  type CategoryValidationErrors,
+} from '~/types/Category';
+import { useTranslation } from 'react-i18next';
+import { useFetcher } from '@remix-run/react';
+import { type APIResponse } from '~/types/Responses';
+import { type CategoryErrors } from '~/types/Validations';
+import { useEffect, useState } from 'react';
+import { type SupportedLanguages } from '~/i18n';
+import { convertCategoryFormValuesToFormData } from '~/utils/content';
+import Toggle, { type ToggleOption } from '~/components/Toggle';
+import Message from '~/components/Message';
+import TextInput from '~/components/TextInput';
+import slugify from '@sindresorhus/slugify';
+import SlugInput from '~/components/SlugInput';
+import TextAreaInput from '~/components/TextAreaInput';
+import AnchorLink from '~/components/AnchorLink';
+import Icon from '~/components/Icon';
+import Button from '~/components/Button';
+
+type Props = {
+  mode: 'create' | 'update';
+  initialValues?: CategoryFormValues;
+  errors?: CategoryValidationErrors;
+  backLink: string;
+  backLinkLabel: string;
+};
+
+export default function CategoryMutationForm({
+  mode,
+  initialValues,
+  errors,
+  backLink,
+  backLinkLabel,
+}: Props) {
+  const { t } = useTranslation('components');
+  const fetcher = useFetcher<APIResponse | CategoryErrors>();
+
+  const [error, setError] = useState('');
+  const [formErrors, setFormErrors] = useState<CategoryErrors>();
+  const [lang, setLang] = useState<SupportedLanguages>('nl');
+
+  const [enName, setEnName] = useState(initialValues?.name.en ?? '');
+  const [nlName, setNlName] = useState(initialValues?.name.nl ?? '');
+  const [enSlug, setEnSlug] = useState(initialValues?.slug.en ?? '');
+  const [nlSlug, setNlSlug] = useState(initialValues?.slug.nl ?? '');
+  const [enDescription, setEnDescription] = useState(
+    initialValues?.description.en ?? ''
+  );
+  const [nlDescription, setNlDescription] = useState(
+    initialValues?.description.nl ?? ''
+  );
+
+  useEffect(() => {
+    if (fetcher.data) {
+      if ('ok' in fetcher.data) {
+        const data = fetcher.data as APIResponse;
+
+        if (!data.ok) {
+          setError(data.message);
+        }
+      } else {
+        const data = fetcher.data as CategoryErrors;
+        setFormErrors(data);
+      }
+    }
+  }, [fetcher.data]);
+
+  const handleLangSelect = (value: string) => {
+    setLang(value as SupportedLanguages);
+  };
+
+  const getLocalisedError = (key: string) => {
+    if (formErrors && lang === 'en') {
+      return formErrors[key as keyof CategoryErrors]?.en;
+    } else if (formErrors && lang === 'nl') {
+      return formErrors[key as keyof CategoryErrors]?.nl;
+    } else {
+      return '';
+    }
+  };
+
+  const getName = () => {
+    if (lang === 'en') {
+      return enName;
+    } else {
+      return nlName;
+    }
+  };
+  const handleNameChange = (name: string) => {
+    if (lang === 'en') {
+      setEnName(name);
+    } else {
+      setNlName(name);
+    }
+  };
+
+  const getSlug = () => {
+    if (lang === 'en') {
+      return enSlug;
+    } else {
+      return nlSlug;
+    }
+  };
+  const handleSlugChange = (slug: string) => {
+    if (lang === 'en') {
+      setEnSlug(slug);
+    } else {
+      setNlSlug(slug);
+    }
+  };
+
+  const getDescription = () => {
+    if (lang === 'en') {
+      return enDescription;
+    } else {
+      return nlDescription;
+    }
+  };
+  const handleDescriptionChange = (summary: string) => {
+    if (lang === 'en') {
+      setEnDescription(summary);
+    } else {
+      setNlDescription(summary);
+    }
+  };
+
+  const generateFormDataFromCategoryValues = (): FormData => {
+    const data: CategoryFormValues = {
+      id: initialValues?.id,
+      name: {
+        en: enName,
+        nl: nlName,
+      },
+      slug: {
+        en: enSlug,
+        nl: nlSlug,
+      },
+      description: {
+        en: enDescription,
+        nl: nlDescription,
+      },
+    };
+
+    return convertCategoryFormValuesToFormData(data);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const data = generateFormDataFromCategoryValues();
+    data.append(
+      'mode',
+      ((e.nativeEvent as SubmitEvent).submitter as HTMLButtonElement)?.value
+    );
+
+    fetcher.submit(data, {
+      action: '/api/categories',
+      method: mode === 'create' ? 'POST' : 'PUT',
+    });
+  };
+
+  const getLanguageOptions = (): ToggleOption[] => {
+    const languageOptions: ToggleOption[] = [
+      {
+        label: t('CategoryMutationForm.LanguageToggleLabels.Dutch'),
+        value: 'nl',
+      },
+      {
+        label: t('CategoryMutationForm.LanguageToggleLabels.English'),
+        value: 'en',
+      },
+    ];
+
+    if (formErrors) {
+      const dutchErrorCount = Object.keys(formErrors).filter((key) => {
+        return formErrors[key as keyof CategoryErrors]?.nl;
+      }).length;
+
+      const englishErrorCount = Object.keys(formErrors).filter((key) => {
+        return formErrors[key as keyof CategoryErrors]?.en;
+      }).length;
+
+      if (dutchErrorCount > 0) {
+        languageOptions.filter(
+          (option) => option.value === 'nl'
+        )[0].notificationCount = dutchErrorCount;
+      }
+
+      if (englishErrorCount > 0) {
+        languageOptions.filter(
+          (option) => option.value === 'en'
+        )[0].notificationCount = englishErrorCount;
+      }
+    }
+
+    return languageOptions;
+  };
+
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <form className="w-full flex flex-col space-y-4" onSubmit={handleSubmit}>
+      <Message variant="error" message={error} />
+
+      <Toggle options={getLanguageOptions()} onSelect={handleLangSelect} />
+
+      <input type="hidden" name="categoryID" defaultValue={initialValues?.id} />
+
+      <TextInput
+        className="w-3/4"
+        name="name"
+        label={t('CategoryMutationForm.Name Label')}
+        value={getName()}
+        onChange={(e) => handleNameChange(e.target.value)}
+        onBlur={(e) => handleSlugChange(slugify(e.target.value))}
+        error={getLocalisedError('name')}
+      />
+
+      <SlugInput
+        className="w-3/4"
+        name="slug"
+        label={t('CategoryMutationForm.Slug Label')}
+        value={getSlug()}
+        onChange={(e) => handleSlugChange(e.target.value)}
+        error={getLocalisedError('slug')}
+      />
+
+      <TextAreaInput
+        className="w-3/4"
+        label={t('CategoryMutationForm.Description Label')}
+        name="description"
+        value={getDescription()}
+        onChange={(e) => handleDescriptionChange(e.target.value)}
+        error={getLocalisedError('description')}
+      />
+
+      <div className="flex flex-row justify-between items-center">
+        <AnchorLink to={backLink}>
+          <Icon className="mr-1" name="arrow-left" /> {backLinkLabel}
+        </AnchorLink>
+
+        <div className="flex flex-row gap-2">
+          <Button disabled={isSubmitting} primary type="submit">
+            {mode === 'create'
+              ? t('CategoryMutationForm.Save Button Label')
+              : t('CategoryMutationForm.Edit Button Label')}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -25,6 +25,7 @@ const adminMenuItems: NavItem[] = [
 ];
 
 const contentMenuItems: NavItem[] = [
+  { title: 'Categorieën', to: '/administratie/categorieen', icon: 'tags' },
   { title: 'Artikelen', to: '/administratie/artikelen', icon: 'file-lines' },
   { title: 'Webinars', to: '/administratie/webinars', icon: 'file-video' },
   { title: 'Tools', to: '/administratie/tools', icon: 'file-zipper' },

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -14,9 +14,15 @@ type Props = {
   columns: string[];
   tableData: TableData[];
   onEdit: (id: string) => void;
+  deletionEndpoint: string;
 };
 
-export default function Table({ tableData, columns, onEdit }: Props) {
+export default function Table({
+  tableData,
+  columns,
+  onEdit,
+  deletionEndpoint,
+}: Props) {
   return (
     <div>
       <table className="table-fixed w-full border-collapse border border-light-pink">
@@ -54,7 +60,7 @@ export default function Table({ tableData, columns, onEdit }: Props) {
 
                 <DeleteItemDialog
                   itemToDelete={{ id, name: data.get('Titel') ?? '' }}
-                  deletionEndpoint="/api/articles"
+                  deletionEndpoint={deletionEndpoint}
                 />
               </td>
             </tr>

--- a/app/models/categories.server.ts
+++ b/app/models/categories.server.ts
@@ -11,3 +11,7 @@ export function getCategories() {
     orderBy: { name: 'asc' },
   });
 }
+
+export function getCategoryById(id: Category['id']) {
+  return prisma.category.findUniqueOrThrow({ where: { id } });
+}

--- a/app/routes/administratie.categorieen._index.tsx
+++ b/app/routes/administratie.categorieen._index.tsx
@@ -5,63 +5,63 @@ import {
 } from '@remix-run/node';
 import { useTranslation } from 'react-i18next';
 import { requireUserWithMinimumRole } from '~/session.server';
-import { getArticlesSummaryList } from '~/models/articles.server';
 import Button from '~/components/Button';
 import { useLoaderData, useNavigate } from '@remix-run/react';
-import { convertArticleListToTableData } from '~/utils/content';
+import { convertCategoryListToTableData } from '~/utils/content';
 import Table from '~/components/Table';
 import { type SupportedLanguages } from '~/i18n';
 import i18nextServer from '~/i18next.server';
+import { getCategories } from '~/models/categories.server';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUserWithMinimumRole('CONSULTANT', request);
 
-  const articles = await getArticlesSummaryList();
+  const categories = await getCategories();
 
   const t = await i18nextServer.getFixedT(request, 'routes');
   const metaTranslations = {
-    title: t('Articles.Index.Meta.Title'),
+    title: t('Categories.Index.Meta.Title'),
   };
 
-  return json({ user, articles, metaTranslations });
+  return json({ user, categories, metaTranslations });
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
   { title: data?.metaTranslations.title ?? 'Drakenfruit' },
 ];
 
-export default function ArticlesIndexRoute() {
+export default function CategoriesIndexRoute() {
   const { t, i18n } = useTranslation('routes');
   const navigate = useNavigate();
-  const { articles } = useLoaderData<typeof loader>();
-  const [columns, data] = convertArticleListToTableData(
-    articles,
+  const { categories } = useLoaderData<typeof loader>();
+  const [columns, data] = convertCategoryListToTableData(
+    categories,
     i18n.language as SupportedLanguages
   );
 
   const handleEdit = (id: string) => {
-    navigate(`/administratie/artikelen/bewerken/${id}`);
+    navigate(`/administratie/categorieen/bewerken/${id}`);
   };
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
-        <h1 className="font-heading text-4xl">{t('Articles.Index.Title')}</h1>
+        <h1 className="font-heading text-4xl">{t('Categories.Index.Title')}</h1>
 
-        <Button to="/administratie/artikelen/nieuw">
-          {t('Articles.Index.New Article')}
+        <Button to="/administratie/categorieen/nieuw">
+          {t('Categories.Index.New Category')}
         </Button>
       </div>
 
-      {articles.length > 0 ? (
+      {categories.length > 0 ? (
         <Table
           columns={columns}
           tableData={data}
           onEdit={handleEdit}
-          deletionEndpoint="/api/articles"
+          deletionEndpoint="/api/categories"
         />
       ) : (
-        <p>{t('Articles.Index.No Articles')}</p>
+        <p>{t('Categories.Index.No Categories')}</p>
       )}
     </div>
   );

--- a/app/routes/administratie.categorieen.bewerken.$id.tsx
+++ b/app/routes/administratie.categorieen.bewerken.$id.tsx
@@ -1,0 +1,57 @@
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import CategoryMutationForm from '~/components/CategoryMutationForm';
+import { requireUserWithMinimumRole } from '~/session.server';
+import i18next from '~/i18next.server';
+import { getCategoryById } from '~/models/categories.server';
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const user = await requireUserWithMinimumRole('CONSULTANT', request);
+
+  const t = await i18next.getFixedT(request, 'routes');
+
+  const { id } = params;
+  invariant(id != null, t('Categories.Edit.Error.No ID'));
+
+  try {
+    const categories = await getCategoryById(id);
+
+    const metaTranslations = {
+      title: t('Categories.Edit.Meta.Title'),
+    };
+
+    return json({
+      user,
+      categories,
+      metaTranslations,
+    });
+  } catch (error) {
+    throw new Error(t('Categories.Edit.Error.Category Not Found'));
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  {
+    title: data?.metaTranslations.title ?? 'Drakenfruit',
+  },
+];
+
+export default function NewCategoryRoute() {
+  const { t } = useTranslation('routes');
+  const { categories } = useLoaderData<typeof loader>();
+
+  return (
+    <CategoryMutationForm
+      mode="update"
+      initialValues={categories}
+      backLink="/administratie/categories"
+      backLinkLabel={t('Categories.Edit.Back Link Label')}
+    />
+  );
+}

--- a/app/routes/administratie.categorieen.nieuw.tsx
+++ b/app/routes/administratie.categorieen.nieuw.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from '@remix-run/node';
+import { requireUserWithMinimumRole } from '~/session.server';
+import i18next from '~/i18next.server';
+import CategoryMutationForm from '~/components/CategoryMutationForm';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithMinimumRole('CONSULTANT', request);
+
+  const t = await i18next.getFixedT(request, 'routes');
+  const metaTranslations = {
+    title: t('Categories.New.Meta.Title'),
+  };
+
+  return json({
+    metaTranslations,
+  });
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  {
+    title: data?.metaTranslations.title ?? 'Drakenfruit',
+  },
+];
+
+export default function NewCategoryRoute() {
+  const { t } = useTranslation('routes');
+
+  return (
+    <CategoryMutationForm
+      mode="create"
+      backLink="/administratie/categories"
+      backLinkLabel={t('Categories.New.Back Link Label')}
+    />
+  );
+}

--- a/app/routes/administratie.categorieen.tsx
+++ b/app/routes/administratie.categorieen.tsx
@@ -9,7 +9,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ user });
 }
 
-export default function ArticlesRoute() {
+export default function CategoriesRoute() {
   const { user } = useLoaderData<typeof loader>();
 
   return <AccountLayout user={user} />;

--- a/app/routes/api.categories.tsx
+++ b/app/routes/api.categories.tsx
@@ -1,0 +1,146 @@
+import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
+import {
+  getSession,
+  requireUserWithMinimumRole,
+  commitSession,
+} from '~/session.server';
+import { convertFormDataToCategoryFormValues } from '~/utils/content';
+import { prisma } from '~/db.server';
+import { type APIResponse } from '~/types/Responses';
+import { getErrorMessage } from '~/utils/utils';
+import i18nextServer from '~/i18next.server';
+import { validateCategory } from '~/validations/flows';
+import { type CategoryErrors } from '~/types/Validations';
+import { type Prisma } from '@prisma/client';
+
+export async function action({ request }: ActionFunctionArgs) {
+  await requireUserWithMinimumRole('CONSULTANT', request);
+
+  const t = await i18nextServer.getFixedT(request, 'routes');
+
+  const clonedRequest = request.clone();
+  const formData = await clonedRequest.formData();
+
+  if (request.method === 'POST') {
+    const validationResults = await validateCategory(request);
+
+    if (!validationResults.success) {
+      return json<CategoryErrors>(validationResults.errors, { status: 400 });
+    } else {
+      const data = convertFormDataToCategoryFormValues(formData);
+
+      try {
+        await prisma.category.create({
+          data: {
+            name: data.name,
+            slug: data.slug,
+            description: data.description,
+          },
+        });
+
+        const session = await getSession(request);
+        session.flash('toast', {
+          title: t('Categories.API.CREATE.Success.Title'),
+          description: t('Categories.API.CREATE.Success.Message'),
+        });
+
+        return redirect('/administratie/categorieen', {
+          headers: {
+            'Set-Cookie': await commitSession(session),
+          },
+        });
+      } catch (error) {
+        const message = getErrorMessage(error);
+        return json<APIResponse>(
+          {
+            ok: false,
+            message,
+          },
+          { status: 500 }
+        );
+      }
+    }
+  }
+
+  if (request.method === 'PUT') {
+    const validationResults = await validateCategory(request);
+
+    if (!validationResults.success) {
+      return json<CategoryErrors>(validationResults.errors, { status: 400 });
+    } else {
+      const categoryFormValues = convertFormDataToCategoryFormValues(formData);
+
+      const data: Prisma.CategoryUpdateInput = {
+        id: categoryFormValues.id,
+        name: categoryFormValues.name,
+        slug: categoryFormValues.slug,
+        description: categoryFormValues.description,
+      };
+
+      try {
+        await prisma.category.update({
+          where: {
+            id: categoryFormValues.id,
+          },
+          data,
+        });
+
+        const session = await getSession(request);
+        session.flash('toast', {
+          title: t('Categories.API.UPDATE.Success.Title'),
+          description: t('Categories.API.UPDATE.Success.Message'),
+        });
+
+        return redirect('/administratie/categorieen', {
+          headers: {
+            'Set-Cookie': await commitSession(session),
+          },
+        });
+      } catch (error) {
+        const message = getErrorMessage(error);
+        return json<APIResponse>({ ok: false, message }, { status: 500 });
+      }
+    }
+  }
+
+  if (request.method === 'DELETE') {
+    const id = (formData.get('id') as string | undefined) ?? '';
+
+    if (!id) {
+      return json<APIResponse>({
+        ok: false,
+        message: t('Categories.API.Delete.Error.NoId'),
+      });
+    } else {
+      try {
+        await prisma.category.delete({
+          where: {
+            id,
+          },
+        });
+
+        const session = await getSession(request);
+        session.flash('toast', {
+          title: t('Categories.API.DELETE.Success.Title'),
+          description: t('Categories.API.DELETE.Success.Message'),
+          destructive: true,
+        });
+
+        return json<APIResponse>(
+          { ok: true },
+          {
+            headers: {
+              'Set-Cookie': await commitSession(session),
+            },
+          }
+        );
+      } catch (error) {
+        console.error(error);
+        const message = getErrorMessage(error);
+        return json<APIResponse>({ ok: false, message }, { status: 500 });
+      }
+    }
+  }
+
+  return json({});
+}

--- a/app/types/Article.ts
+++ b/app/types/Article.ts
@@ -1,3 +1,5 @@
+import { type SerializedArticle as Article } from '~/models/articles.server';
+
 export type ArticleValidationErrors = {
   image?: string;
   title?: string;
@@ -5,4 +7,13 @@ export type ArticleValidationErrors = {
   content?: string;
   author?: string;
   categories?: string;
+};
+
+export type ArticleFormValues = Omit<
+  Article,
+  'id' | 'published' | 'createdAt' | 'updatedAt'
+> & {
+  id?: string;
+  categories: string[];
+  published?: boolean;
 };

--- a/app/types/Category.ts
+++ b/app/types/Category.ts
@@ -1,0 +1,14 @@
+import { type Category } from '~/models/categories.server';
+
+export type CategoryValidationErrors = {
+  name?: string;
+  slug?: string;
+  description?: string;
+};
+
+export type CategoryFormValues = Omit<
+  Category,
+  'id' | 'createdAt' | 'updatedAt'
+> & {
+  id?: string;
+};

--- a/app/types/Validations.ts
+++ b/app/types/Validations.ts
@@ -1,4 +1,5 @@
-import { type ArticleFormValues } from '~/components/ArticleMutationForm';
+import { type ArticleFormValues } from '~/types/Article';
+import { type CategoryFormValues } from '~/types/Category';
 
 interface BaseValidationResult {
   success: boolean;
@@ -37,4 +38,10 @@ export type ArticleData = ArticleFormValues;
 
 export type ArticleErrors = Partial<
   Record<keyof ArticleFormValues, { nl?: string; en?: string }>
+>;
+
+export type CategoryData = CategoryFormValues;
+
+export type CategoryErrors = Partial<
+  Record<keyof CategoryFormValues, { nl?: string; en?: string }>
 >;

--- a/app/utils/content.test.ts
+++ b/app/utils/content.test.ts
@@ -8,8 +8,13 @@ import {
   convertArticleFormValuesToFormData,
   convertFormDataToArticleFormValues,
   convertPrismaArticleToArticleFormValues,
+  convertCategoryListToTableData,
+  convertCategoryFormValuesToFormData,
+  convertFormDataToCategoryFormValues,
 } from '~/utils/content';
-import { type ArticleFormValues } from '~/components/ArticleMutationForm';
+import { type Category } from '~/models/categories.server';
+import { type ArticleFormValues } from '~/types/Article';
+import { type CategoryFormValues } from '~/types/Category';
 
 describe('Content utilities', () => {
   describe('Articles', () => {
@@ -226,30 +231,63 @@ describe('Content utilities', () => {
         published: true,
       });
     });
-  });
 
-  test('Converting the article data of an unpublished article from Prisma to an ArticleFormValue', () => {
-    const articleFromPrisma: Awaited<ReturnType<typeof getArticleById>> = {
-      id: '1',
-      title: { en: 'Title 1', nl: 'Titel 1' },
-      slug: { en: 'title-1', nl: 'titel-1' },
-      published: false,
-      summary: { en: 'Summary 1', nl: 'Samenvatting 1' },
-      authorId: '1',
-      author: {
+    test('Converting the article data of an unpublished article from Prisma to an ArticleFormValue', () => {
+      const articleFromPrisma: Awaited<ReturnType<typeof getArticleById>> = {
         id: '1',
-        firstName: 'Kaylee',
-        lastName: 'Rosalina',
-        role: 'ADMIN',
-        locale: 'nl',
-        email: 'kaylee@drakenfruit.com',
-        organisationId: '1',
-        avatarUrl: null,
+        title: { en: 'Title 1', nl: 'Titel 1' },
+        slug: { en: 'title-1', nl: 'titel-1' },
+        published: false,
+        summary: { en: 'Summary 1', nl: 'Samenvatting 1' },
+        authorId: '1',
+        author: {
+          id: '1',
+          firstName: 'Kaylee',
+          lastName: 'Rosalina',
+          role: 'ADMIN',
+          locale: 'nl',
+          email: 'kaylee@drakenfruit.com',
+          organisationId: '1',
+          avatarUrl: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        content: { en: 'Content 1', nl: 'Inhoud 1' },
+        categories: [
+          {
+            id: '1',
+            name: { en: 'Category 1', nl: 'Categorie 1' },
+            slug: { en: 'category-1', nl: 'categorie-1' },
+            description: { en: 'Description 1', nl: 'Beschrijving 1' },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        image: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-      },
-      content: { en: 'Content 1', nl: 'Inhoud 1' },
-      categories: [
+      };
+
+      const article =
+        convertPrismaArticleToArticleFormValues(articleFromPrisma);
+
+      expect(article).toEqual<ArticleFormValues>({
+        id: '1',
+        title: { en: 'Title 1', nl: 'Titel 1' },
+        slug: { en: 'title-1', nl: 'titel-1' },
+        summary: { en: 'Summary 1', nl: 'Samenvatting 1' },
+        content: { en: 'Content 1', nl: 'Inhoud 1' },
+        categories: ['1'],
+        authorId: '1',
+        image: null,
+        published: false,
+      });
+    });
+  });
+
+  describe('Categories', () => {
+    test('Converting a list of categories from the database into table data', () => {
+      const categories: Category[] = [
         {
           id: '1',
           name: { en: 'Category 1', nl: 'Categorie 1' },
@@ -258,24 +296,63 @@ describe('Content utilities', () => {
           createdAt: new Date(),
           updatedAt: new Date(),
         },
-      ],
-      image: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+      ];
 
-    const article = convertPrismaArticleToArticleFormValues(articleFromPrisma);
+      const [columns, data] = convertCategoryListToTableData(categories, 'en');
 
-    expect(article).toEqual<ArticleFormValues>({
+      expect(columns).toEqual(['Naam', 'Slug', 'Beschrijving']);
+
+      expect(data).toEqual([
+        {
+          id: '1',
+          data: new Map([
+            ['Naam', 'Category 1'],
+            ['Slug', 'category-1'],
+            ['Beschrijving', 'Description 1'],
+          ]),
+        },
+      ]);
+    });
+
+    test('Convert a CategoryFormValue into FormData object', () => {
+      const category: Category = {
+        id: '1',
+        name: { en: 'Category 1', nl: 'Categorie 1' },
+        slug: { en: 'category-1', nl: 'categorie-1' },
+        description: { en: 'Description 1', nl: 'Beschrijving 1' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const formData = convertCategoryFormValuesToFormData(category);
+
+      expect(formData.get('id')).toEqual('1');
+      expect(formData.get('name.en')).toEqual('Category 1');
+      expect(formData.get('name.nl')).toEqual('Categorie 1');
+      expect(formData.get('slug.en')).toEqual('category-1');
+      expect(formData.get('slug.nl')).toEqual('categorie-1');
+      expect(formData.get('description.en')).toEqual('Description 1');
+      expect(formData.get('description.nl')).toEqual('Beschrijving 1');
+    });
+  });
+
+  test('Convert FormData to CategoryFormValue', () => {
+    const formData = new FormData();
+    formData.append('id', '1');
+    formData.append('name.en', 'Category 1');
+    formData.append('name.nl', 'Categorie 1');
+    formData.append('slug.en', 'category-1');
+    formData.append('slug.nl', 'categorie-1');
+    formData.append('description.en', 'Description 1');
+    formData.append('description.nl', 'Beschrijving 1');
+
+    const category = convertFormDataToCategoryFormValues(formData);
+
+    expect(category).toEqual<CategoryFormValues>({
       id: '1',
-      title: { en: 'Title 1', nl: 'Titel 1' },
-      slug: { en: 'title-1', nl: 'titel-1' },
-      summary: { en: 'Summary 1', nl: 'Samenvatting 1' },
-      content: { en: 'Content 1', nl: 'Inhoud 1' },
-      categories: ['1'],
-      authorId: '1',
-      image: null,
-      published: false,
+      name: { en: 'Category 1', nl: 'Categorie 1' },
+      slug: { en: 'category-1', nl: 'categorie-1' },
+      description: { en: 'Description 1', nl: 'Beschrijving 1' },
     });
   });
 });

--- a/app/utils/content.ts
+++ b/app/utils/content.ts
@@ -3,8 +3,10 @@ import {
   type getArticleById,
 } from '~/models/articles.server';
 import { type Columns, type TableData } from '~/components/Table';
-import { type ArticleFormValues } from '~/components/ArticleMutationForm';
 import { type SupportedLanguages } from '~/i18n';
+import { type Category } from '~/models/categories.server';
+import { type ArticleFormValues } from '~/types/Article';
+import { type CategoryFormValues } from '~/types/Category';
 
 export function convertArticleListToTableData(
   articles: ArticlesWithCategoriesSummaryList[],
@@ -125,4 +127,69 @@ export function convertPrismaArticleToArticleFormValues(
     image: article.image,
     published: article.published,
   };
+}
+
+export function convertCategoryListToTableData(
+  categories: Category[],
+  lang: SupportedLanguages
+): [Columns, TableData[]] {
+  const columns: Columns = ['Naam', 'Slug', 'Beschrijving'];
+
+  const data: TableData[] = categories.map((category) => {
+    return {
+      id: category.id,
+      data: new Map([
+        ['Naam', category.name[lang]],
+        ['Slug', category.slug[lang]],
+        ['Beschrijving', category.description[lang]],
+      ]),
+    };
+  });
+
+  return [columns, data];
+}
+
+export function convertCategoryFormValuesToFormData(
+  categoryFormValues: CategoryFormValues
+): FormData {
+  const formData = new FormData();
+
+  formData.append('name.en', categoryFormValues.name.en);
+  formData.append('name.nl', categoryFormValues.name.nl);
+  formData.append('slug.en', categoryFormValues.slug.en);
+  formData.append('slug.nl', categoryFormValues.slug.nl);
+  formData.append('description.en', categoryFormValues.description.en);
+  formData.append('description.nl', categoryFormValues.description.nl);
+
+  if (categoryFormValues.id) {
+    formData.append('id', categoryFormValues.id);
+  }
+
+  return formData;
+}
+
+export function convertFormDataToCategoryFormValues(
+  formData: FormData
+): CategoryFormValues {
+  const categoryFormValues: CategoryFormValues = {
+    name: {
+      en: formData.get('name.en') as string,
+      nl: formData.get('name.nl') as string,
+    },
+    slug: {
+      en: formData.get('slug.en') as string,
+      nl: formData.get('slug.nl') as string,
+    },
+    description: {
+      en: formData.get('description.en') as string,
+      nl: formData.get('description.nl') as string,
+    },
+  };
+
+  const id = formData.get('id') as string | null;
+  if (id) {
+    categoryFormValues.id = id;
+  }
+
+  return categoryFormValues;
 }

--- a/app/utils/icons.ts
+++ b/app/utils/icons.ts
@@ -20,4 +20,5 @@ export {
   faTimes,
   faArrowLeft,
   faSpinner,
+  faTags,
 } from '@fortawesome/free-solid-svg-icons';

--- a/app/validations/flows.test.ts
+++ b/app/validations/flows.test.ts
@@ -81,31 +81,81 @@ describe('Validating user flows', () => {
       nl: 'Waarde is verplicht',
     });
     expect(validationResult.data).toBe(undefined);
+
+    test('Check whether an article request is invalid because of a singular missing slug', async () => {
+      const formData = new FormData();
+      formData.append('id', '1');
+      formData.append('slug.en', 'title-1');
+      formData.append('summary.en', 'Summary 1');
+      formData.append('summary.nl', 'Samenvatting 1');
+      formData.append('content.en', 'Content 1');
+      formData.append('content.nl', 'Inhoud 1');
+      formData.append('categories', '1,2');
+      formData.append('authorId', '1');
+      formData.append('image', '/path/to/image.jpg');
+
+      const request = new Request('http://localhost:3000/api/article', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const validationResult = await validationFlows.validateArticle(request);
+
+      expect(validationResult.success).toBe(false);
+      expect(validationResult.errors!.slug).toStrictEqual({
+        nl: 'Waarde is verplicht',
+      });
+      expect(validationResult.data).toBe(undefined);
+    });
   });
 
-  test('Check whether an article request is invalid because of a singular missing slug', async () => {
-    const formData = new FormData();
-    formData.append('id', '1');
-    formData.append('slug.en', 'title-1');
-    formData.append('summary.en', 'Summary 1');
-    formData.append('summary.nl', 'Samenvatting 1');
-    formData.append('content.en', 'Content 1');
-    formData.append('content.nl', 'Inhoud 1');
-    formData.append('categories', '1,2');
-    formData.append('authorId', '1');
-    formData.append('image', '/path/to/image.jpg');
+  describe('Category validation', () => {
+    test('Check whether a category request is valid or not', async () => {
+      const formData = new FormData();
+      formData.append('id', '1');
+      formData.append('name.en', 'Name 1');
+      formData.append('name.nl', 'Naam 1');
+      formData.append('slug.en', 'name-1');
+      formData.append('slug.nl', 'naam-1');
+      formData.append('description.en', 'Description 1');
+      formData.append('description.nl', 'Beschrijving 1');
 
-    const request = new Request('http://localhost:3000/api/article', {
-      method: 'POST',
-      body: formData,
+      const request = new Request('http://localhost:3000/api/category', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const validationResult = await validationFlows.validateCategory(request);
+
+      expect(validationResult.success).toBe(true);
+      expect(validationResult.data).toStrictEqual({
+        name: { en: 'Name 1', nl: 'Naam 1' },
+        slug: { en: 'name-1', nl: 'naam-1' },
+        description: { en: 'Description 1', nl: 'Beschrijving 1' },
+      });
     });
 
-    const validationResult = await validationFlows.validateArticle(request);
+    test('Check whether a category request is invalid because of missing names', async () => {
+      const formData = new FormData();
+      formData.append('id', '1');
+      formData.append('slug.en', 'name-1');
+      formData.append('slug.nl', 'naam-1');
+      formData.append('description.en', 'Description 1');
+      formData.append('description.nl', 'Beschrijving 1');
 
-    expect(validationResult.success).toBe(false);
-    expect(validationResult.errors!.slug).toStrictEqual({
-      nl: 'Waarde is verplicht',
+      const request = new Request('http://localhost:3000/api/category', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const validationResult = await validationFlows.validateCategory(request);
+
+      expect(validationResult.success).toBe(false);
+      expect(validationResult.errors!.name).toStrictEqual({
+        en: 'Waarde is verplicht',
+        nl: 'Waarde is verplicht',
+      });
+      expect(validationResult.data).toBe(undefined);
     });
-    expect(validationResult.data).toBe(undefined);
   });
 });

--- a/app/validations/flows.ts
+++ b/app/validations/flows.ts
@@ -1,6 +1,8 @@
 import type {
   ArticleData,
   ArticleErrors,
+  CategoryData,
+  CategoryErrors,
   LoginData,
   LoginErrors,
   ValidationResult,
@@ -113,5 +115,39 @@ export async function validateArticle(
       authorId: authorId as string,
       image: formData.get('image') as string,
     },
+  };
+}
+
+export async function validateCategory(
+  request: Request
+): Promise<ValidationResult<CategoryData, CategoryErrors>> {
+  const formData = await request.formData();
+
+  const name = {
+    en: formData.get('name.en') as string,
+    nl: formData.get('name.nl') as string,
+  };
+  const slug = {
+    en: formData.get('slug.en') as string,
+    nl: formData.get('slug.nl') as string,
+  };
+  const description = {
+    en: formData.get('description.en') as string,
+    nl: formData.get('description.nl') as string,
+  };
+
+  const errors: CategoryErrors = {};
+
+  errors.name = checks.checkLocalisedValue(name);
+  errors.slug = checks.checkLocalisedValue(slug);
+  errors.description = checks.checkLocalisedValue(description);
+
+  if (Object.keys(errors).some((key) => errors[key as keyof CategoryErrors])) {
+    return { success: false, errors };
+  }
+
+  return {
+    success: true,
+    data: { name, slug, description },
   };
 }

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -48,5 +48,16 @@
     "Message": "Are you sure you want to delete this item?",
     "Cancel Button Label": "Cancel",
     "Delete Button Label": "Delete"
+  },
+  "CategoryMutationForm": {
+    "LanguageToggleLabels": {
+      "Dutch": "Dutch",
+      "English": "English"
+    },
+    "Name Label": "Name",
+    "Slug Label": "Slug",
+    "Description Label": "Description",
+    "Save Button Label": "Save",
+    "Edit Button Label": "Edit"
   }
 }

--- a/public/locales/en/routes.json
+++ b/public/locales/en/routes.json
@@ -30,7 +30,10 @@
     "Index": {
       "Meta": {
         "Title": "Artikelen | Drakenfruit"
-      }
+      },
+      "Title": "Articles",
+      "No Articles": "No articles were found",
+      "New Article": "New article"
     },
     "New": {
       "Meta": {
@@ -47,6 +50,49 @@
         "Article Not Found": "The article could not be found"
       },
       "Back Link Label": "Back to articles"
+    }
+  },
+  "Categories": {
+    "API": {
+      "CREATE": {
+        "Success": {
+          "Title": "Category created",
+          "Message": "The category was created successfully"
+        }
+      },
+      "UPDATE": {
+        "Success": {
+          "Title": "Category updated",
+          "Message": "The category was updated successfully"
+        },
+        "Error": {
+          "No ID": "No ID was provided",
+          "Category Not Found": "The category could not be found"
+        }
+      },
+      "DELETE": {
+        "Success": {
+          "Title": "Category deleted",
+          "Message": "The category was deleted successfully"
+        },
+        "Error": {
+          "No ID": "No ID was provided"
+        }
+      }
+    },
+    "Index": {
+      "Meta": {
+        "Title": "Categories | Drakenfruit"
+      },
+      "Title": "Categories",
+      "No Categories": "No categories were found",
+      "New Category": "New category"
+    },
+    "New": {
+      "Meta": {
+        "Title": "New category | Drakenfruit"
+      },
+      "Back Link Label": "Back to categories"
     }
   }
 }

--- a/public/locales/nl/components.json
+++ b/public/locales/nl/components.json
@@ -48,5 +48,16 @@
     "Message": "Weet je zeker dat je dit item wilt verwijderen?",
     "Cancel Button Label": "Annuleren",
     "Delete Button Label": "Verwijderen"
+  },
+  "CategoryMutationForm": {
+    "LanguageToggleLabels": {
+      "Dutch": "Nederlands",
+      "English": "Engels"
+    },
+    "Name Label": "Naam",
+    "Slug Label": "Slug",
+    "Description Label": "Beschrijving",
+    "Save Button Label": "Opslaan",
+    "Edit Button Label": "Bewerken"
   }
 }

--- a/public/locales/nl/routes.json
+++ b/public/locales/nl/routes.json
@@ -30,23 +30,69 @@
     "Index": {
       "Meta": {
         "Title": "Artikelen | Drakenfruit"
-      }
+      },
+      "Title": "Artikelen",
+      "No Articles": "Er zijn nog geen artikelen aangemaakt.",
+      "New Article": "Nieuw artikel"
+    },
+    "New": {
+      "Meta": {
+        "Title": "Nieuw artikel | Drakenfruit"
+      },
+      "Back Link Label": "Terug naar overzicht"
+    },
+    "Edit": {
+      "Meta": {
+        "Title": "Artikel bewerken | Drakenfruit"
+      },
+      "Error": {
+        "No ID": "Geen ID opgegeven",
+        "Article Not Found": "Het artikel kon niet gevonden worden"
+      },
+      "Back Link Label": "Terug naar overzicht"
     }
   },
-  "New": {
-    "Meta": {
-      "Title": "Nieuw artikel | Drakenfruit"
+  "Categories": {
+    "API": {
+      "CREATE": {
+        "Success": {
+          "Title": "Category created",
+          "Message": "The category was created successfully"
+        }
+      },
+      "UPDATE": {
+        "Success": {
+          "Title": "Category updated",
+          "Message": "The category was updated successfully"
+        },
+        "Error": {
+          "No ID": "No ID was provided",
+          "Category Not Found": "The category could not be found"
+        }
+      },
+      "DELETE": {
+        "Success": {
+          "Title": "Category deleted",
+          "Message": "The category was deleted successfully"
+        },
+        "Error": {
+          "No ID": "No ID was provided"
+        }
+      }
     },
-    "Back Link Label": "Terug naar overzicht"
-  },
-  "Edit": {
-    "Meta": {
-      "Title": "Artikel bewerken | Drakenfruit"
+    "Index": {
+      "Meta": {
+        "Title": "Categorieën | Drakenfruit"
+      },
+      "Title": "Categorieën",
+      "No Categories": "Er zijn nog geen categorieën aangemaakt.",
+      "New Category": "Nieuwe categorie"
     },
-    "Error": {
-      "No ID": "Geen ID opgegeven",
-      "Article Not Found": "Het artikel kon niet gevonden worden"
-    },
-    "Back Link Label": "Terug naar overzicht"
+    "New": {
+      "Meta": {
+        "Title": "Nieuwe categorie | Drakenfruit"
+      },
+      "Back Link Label": "Terug naar overzicht"
+    }
   }
 }

--- a/remix.config.js
+++ b/remix.config.js
@@ -6,5 +6,9 @@ module.exports = {
   serverModuleFormat: 'cjs',
   devServerPort: 8002,
   tailwind: true,
-  serverDependenciesToBundle: [/@sindresorhus/, /remix-utils/],
+  serverDependenciesToBundle: [
+    /@sindresorhus/,
+    /remix-utils/,
+    /escape-string-regexp/,
+  ],
 };


### PR DESCRIPTION
* release/phase 1 (#9)

* feature/dra 36 update to remix v2 (#1)

* Updated dependencies, most notably Remix v2!!

* Fixed TypeScript errors, and prevented test suites from breaking the build.

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* Feature/dra 35 internationalisation (#2)

* Added i18Next for internationalisation support, and made the custom server play nice with Remix Dev

* Added fix for running Cypress

* Hard-coded Remix dev origin URL

* Updated custom server to the current Blues Stack template

* Added types for the source map support package

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* Set up database schema (which is strongly typed) and seeded users. (#3)

* Set up database schema (which is strongly typed) and seeded users.

* Fixed TypeScript error

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* Expanded the roleset with "OFFICEMANAGER", and added models for organisations and projects. (#4)

* Expanded the roleset with "OFFICEMANAGER", and added models for organisations and projects.

* Fixed typecheck errors, and added Storybook export dir to ESLint ignores

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* feature/dra 7 user management route in admin section (#5)

* Basic setup of login flow with new components and validation flow

* Updated login form with new components and added Checkbox

* Implemented permission- (or roles-)based restrictions in the menu, and an error boundary

* Fixed linting and type check errors

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* feature/dra 13 integrate tinymce (#6)

* Basic setup of login flow with new components and validation flow

* Updated login form with new components and added Checkbox

* Implemented permission- (or roles-)based restrictions in the menu, and an error boundary

* Fixed linting and type check errors

* Integrated TinyMCE editor

* Re-ran npm install

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* feature/dra 15 crud flow for articles (#7)

* Split up content from administration

* Refactored the sidebar a bit so that navigation looks better and is easier

* Started on the articles list and created a Table

* Filled the article overview page

* Started the work for the article mutation form, with improvements to Storybook's i18n handling, various new components and improvements to some "old" components

* Finished the article mutation form with localisation, new components and a lot of improvements.

* Started working on sending the mutation data

* Fixed the wonky i18n form values switching part, and wrote converters for artice and formdata

* Fixed Editor from typing information backwards

* If not specified, the article form will set the author to the current user

* Fixed auto slug generator

* Small improvements to the form's localisation, and added a simple lang switch in the header

* Some improvements to the localisation (although it doesn't seem to work for now), and the article page has a meta tag with localised title.

* Small improvements to the category model in db, and improved the article cRud flow since articles from the server are now listed in the table.

* Implemented a deletion flow with components for the articles cruD flow

* Added functionality to the create flow of the article (Crud), improved the delete flow by adding a toast message that appears

* A lot of improvements to the creation and update flows of articles

* Show draft status of article in the table

* Improved the handling of draft articles in create or update state

* Added validation checks for create and update

* Improved Editor error visualisation, and fixed some linting errors

* Do not run Storybook and Prisma Studio when running Cypress..

* Also adjusted the build script for Cypress

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* Configured the deploy step of GA to deploy to DO's container registry (#8)

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>

* Moved production packages

* Upped version

* Removed package

* Small fixes to configs

* Multi-tagged Docker image so that we can auto-deploy on 'latest' while also keeping the versioned tags

* Started with cRuD flows of categories, and some small improvements for the article crud flow

* Finished CrUd flow for categories

* Updated Prisma steps in Dockerfile

* Renamed DB url to Prod DB Url

* Fixed linting issues

---------

Co-authored-by: Lody Borgers <l.borgers@taf.nl>